### PR TITLE
Add suggestions for long and dd-style options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 
 [dependencies]
 derive = { version = "0.1.0", path = "derive" }
+strsim = "0.10.0"
 lexopt = "0.3.0"
 
 [workspace]


### PR DESCRIPTION
Currently looks like this:
```
error: Found an invalid option '--namr'.
Did you mean: --name
```
or, for dd-style arguments:
```
error: Found an invalid option 'namr'.
Did you mean: name
```

`strsim` is used just like `clap` does it.