### PR TITLE
Add exit code to the error type

### DIFF
--- a/derive/src/argument.rs
+++ b/derive/src/argument.rs
@@ -186,7 +186,7 @@ pub fn short_handling(args: &[Argument]) -> (TokenStream, Vec<char>) {
         Ok(Some(Argument::Custom(
             match short {
                 #(#match_arms)*
-                _ => return Err(::uutils_args::Error::UnexpectedOption(short.to_string(), Vec::new())),
+                _ => return Err(::uutils_args::ErrorKind::UnexpectedOption(short.to_string(), Vec::new())),
             }
         )))
     );
@@ -233,7 +233,7 @@ pub fn long_handling(args: &[Argument], help_flags: &Flags) -> TokenStream {
 
     if options.is_empty() {
         return quote!(
-            return Err(::uutils_args::Error::UnexpectedOption(
+            return Err(::uutils_args::ErrorKind::UnexpectedOption(
                 long.to_string(),
                 Vec::new()
             ))
@@ -321,7 +321,7 @@ pub fn free_handling(args: &[Argument]) -> TokenStream {
             if let Some((prefix, value)) = arg.split_once('=') {
                 #(#dd_branches)*
 
-                return Err(::uutils_args::Error::UnexpectedOption(
+                return Err(::uutils_args::ErrorKind::UnexpectedOption(
                     prefix.to_string(),
                     ::uutils_args::internal::filter_suggestions(prefix, &[#(#dd_args),*], "")
                 ));
@@ -392,9 +392,12 @@ pub fn positional_handling(args: &[Argument]) -> (TokenStream, TokenStream) {
         let mut missing: Vec<&str> = vec![];
         #(#missing_argument_checks)*
         if !missing.is_empty() {
-            Err(uutils_args::Error::MissingPositionalArguments(
-                missing.iter().map(ToString::to_string).collect::<Vec<String>>()
-            ))
+            Err(uutils_args::Error {
+                exit_code: Self::EXIT_CODE,
+                kind: uutils_args::ErrorKind::MissingPositionalArguments(
+                    missing.iter().map(ToString::to_string).collect::<Vec<String>>()
+                )
+            })
         } else {
             Ok(())
         }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -73,7 +73,7 @@ pub fn arguments(input: TokenStream) -> TokenStream {
             #[allow(unreachable_code)]
             fn next_arg(
                 parser: &mut uutils_args::lexopt::Parser, positional_idx: &mut usize
-            ) -> Result<Option<uutils_args::Argument<Self>>, uutils_args::Error> {
+            ) -> Result<Option<::uutils_args::Argument<Self>>, ::uutils_args::ErrorKind> {
                 use uutils_args::{Value, lexopt, Error, Argument};
 
                 #free

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod value;
 pub use lexopt;
 pub use uutils_args_derive::*;
 
-pub use error::Error;
+pub use error::{Error, ErrorKind};
 pub use value::{Value, ValueError, ValueResult};
 
 use std::{ffi::OsString, marker::PhantomData};
@@ -24,12 +24,12 @@ pub enum Argument<T: Arguments> {
     Custom(T),
 }
 
-fn exit_if_err<T>(res: Result<T, Error>, exit_code: i32) -> T {
+fn exit_if_err<T>(res: Result<T, Error>) -> T {
     match res {
         Ok(v) => v,
         Err(err) => {
             eprintln!("{err}");
-            std::process::exit(exit_code);
+            std::process::exit(err.exit_code);
         }
     }
 }
@@ -62,7 +62,7 @@ pub trait Arguments: Sized {
     fn next_arg(
         parser: &mut lexopt::Parser,
         positional_idx: &mut usize,
-    ) -> Result<Option<Argument<Self>>, Error>;
+    ) -> Result<Option<Argument<Self>>, ErrorKind>;
 
     /// Check for any required arguments that have not been found.
     ///
@@ -89,7 +89,7 @@ pub trait Arguments: Sized {
         I: IntoIterator + 'static,
         I::Item: Into<OsString>,
     {
-        exit_if_err(Self::try_check(args), Self::EXIT_CODE)
+        exit_if_err(Self::try_check(args))
     }
 
     /// Check all arguments immediately and return any errors.
@@ -135,10 +135,15 @@ impl<T: Arguments> ArgumentIter<T> {
     }
 
     pub fn next_arg(&mut self) -> Result<Option<T>, Error> {
-        if let Some(arg) = T::next_arg(&mut self.parser, &mut self.positional_idx)? {
+        if let Some(arg) =
+            T::next_arg(&mut self.parser, &mut self.positional_idx).map_err(|kind| Error {
+                exit_code: T::EXIT_CODE,
+                kind,
+            })?
+        {
             match arg {
                 Argument::Help => {
-                    self.help()?;
+                    self.help().unwrap();
                     std::process::exit(0);
                 }
                 Argument::Version => {
@@ -184,7 +189,7 @@ pub trait Options<Arg: Arguments>: Sized {
         I: IntoIterator + 'static,
         I::Item: Into<OsString>,
     {
-        exit_if_err(self.try_parse(args), Arg::EXIT_CODE)
+        exit_if_err(self.try_parse(args))
     }
 
     #[allow(unused_mut)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use crate::error::Error;
+use crate::error::{Error, ErrorKind};
 use std::{
     ffi::{OsStr, OsString},
     path::PathBuf,
@@ -50,7 +50,7 @@ impl std::fmt::Display for ValueError {
 
 /// Defines how a type should be parsed from an argument.
 ///
-/// If an error is returned, it will be wrapped in [`Error::ParsingFailed`]
+/// If an error is returned, it will be wrapped in [`ErrorKind::ParsingFailed`]
 pub trait Value: Sized {
     fn from_value(value: &OsStr) -> ValueResult<Self>;
 
@@ -81,7 +81,11 @@ impl Value for String {
     fn from_value(value: &OsStr) -> ValueResult<Self> {
         match value.to_str() {
             Some(s) => Ok(s.into()),
-            None => Err(Error::NonUnicodeValue(value.into()).into()),
+            None => Err(Error {
+                exit_code: 1,
+                kind: ErrorKind::NonUnicodeValue(value.into()),
+            }
+            .into()),
         }
     }
 }


### PR DESCRIPTION
This makes it possible to convert an error from this library into a `uucore::UError` in the future.