### PR TITLE
ci: remove actions-rs/cargo & use cargo directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features complete --workspace
+      - run: cargo test --features complete --workspace
 
   rustfmt:
     name: Rustfmt
@@ -37,10 +34,7 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -54,10 +48,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Clippy check
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --features complete --workspace -- -D warnings
+        run: cargo clippy --all-targets --features complete --workspace -- -D warnings
 
   docs:
     name: Docs
@@ -71,6 +62,4 @@ jobs:
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
+        run: cargo doc


### PR DESCRIPTION
This PR removes the unmaintained `actions-rs/cargo` and replaces it with direct invocations of `cargo`. It should get rid of the "The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/cargo@v1" warnings.