### PR TITLE
clippy: fix errors

### DIFF
--- a/examples/completion.rs
+++ b/examples/completion.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::path::PathBuf;
 
 use uutils_args::{Arguments, Options, Value};

--- a/tests/coreutils/dd.rs
+++ b/tests/coreutils/dd.rs
@@ -102,14 +102,14 @@ impl Options<Arg> for Settings {
                 self.ibs = b;
                 self.obs = b;
             }
-            Arg::Cbs(_) => todo!(),
+            Arg::Cbs(_b) => todo!(),
             Arg::Skip(b) => self.skip = b,
             Arg::Seek(b) => self.seek = b,
             Arg::Count(n) => self.count = n,
             Arg::Status(level) => self.status = Some(level),
-            Arg::Conv(_) => todo!(),
-            Arg::Iflag(_) => todo!(),
-            Arg::Oflag(_) => todo!(),
+            Arg::Conv(_c) => todo!(),
+            Arg::Iflag(_f) => todo!(),
+            Arg::Oflag(_f) => todo!(),
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bunch of "field x is never read" errors. See, for example, https://github.com/uutils/uutils-args/actions/runs/8533931984/job/23377441182 . It should make the "Clippy" job in the CI pass.