### PR TITLE
fix nightly clippy warnings

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-proc_macro = true
+proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.81"

--- a/derive/src/argument.rs
+++ b/derive/src/argument.rs
@@ -13,7 +13,6 @@ use crate::{
 pub struct Argument {
     pub ident: Ident,
     pub field: Option<syn::Type>,
-    pub name: String,
     pub arg_type: ArgType,
     pub help: String,
 }
@@ -41,7 +40,6 @@ pub fn parse_arguments_attr(attrs: &[Attribute]) -> ArgumentsAttr {
 
 pub fn parse_argument(v: Variant) -> Vec<Argument> {
     let ident = v.ident;
-    let name = ident.to_string();
     let attributes = get_arg_attributes(&v.attrs).unwrap();
 
     // Return early because we don't need to check the fields if it's not used.
@@ -94,7 +92,6 @@ pub fn parse_argument(v: Variant) -> Vec<Argument> {
             Argument {
                 ident: ident.clone(),
                 field: field.clone(),
-                name: name.clone(),
                 arg_type,
                 help: arg_help,
             }

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -286,7 +286,7 @@ fn actions() {
         fn apply(&mut self, arg: Arg) {
             match arg {
                 Arg::Message(m) => {
-                    self.last_message = m.clone();
+                    self.last_message.clone_from(&m);
                     self.messages.push(m);
                 }
                 Arg::Send => self.send = true,
@@ -617,6 +617,7 @@ fn empty_value() {
         Val(V),
     }
 
+    #[allow(dead_code)]
     struct Settings {}
 
     impl Options<Arg> for Settings {


### PR DESCRIPTION
Note that this still compiles warning-free with rustc 1.70.

This is kind of a blocker for #113, because otherwise CI fails during `cargo +nightly clippy`.