### PR TITLE
clippy: fix warning from unnecessary_map_or lint

### DIFF
--- a/derive/src/help_parser.rs
+++ b/derive/src/help_parser.rs
@@ -71,7 +71,7 @@ pub fn parse_usage(content: &str) -> String {
 pub fn parse_section(section: &str, content: &str) -> Option<String> {
     fn is_section_header(line: &str, section: &str) -> bool {
         line.strip_prefix("##")
-            .map_or(false, |l| l.trim().to_lowercase() == section)
+            .is_some_and(|l| l.trim().to_lowercase() == section)
     }
 
     let section = &section.to_lowercase();


### PR DESCRIPTION
This PR fixes a warning from the [unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or) lint.