### PR TITLE
remove 'complete' feature flag, make it unconditional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --features complete --workspace
+      - run: cargo test --workspace
 
   rustfmt:
     name: Rustfmt
@@ -48,7 +48,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Clippy check
-        run: cargo clippy --all-targets --features complete --workspace -- -D warnings
+        run: cargo clippy --all-targets --workspace -- -D warnings
 
   docs:
     name: Docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,12 @@ readme = "README.md"
 
 [dependencies]
 uutils-args-derive = { version = "0.1.0", path = "derive" }
-uutils-args-complete = { version = "0.1.0", path = "complete", optional = true }
+uutils-args-complete = { version = "0.1.0", path = "complete" }
 strsim = "0.11.1"
 lexopt = "0.3.0"
 
 [features]
-parse-is-complete = ["complete"]
-complete = ["uutils-args-complete"]
+parse-is-complete = []
 
 [workspace]
 members = ["derive", "complete"]

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 check:
     cargo fmt --all
-    cargo test --features complete
-    cargo clippy --all-targets --features complete  --workspace -- -D warnings
+    cargo test
+    cargo clippy --all-targets  --workspace -- -D warnings
     cargo doc

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -117,7 +117,6 @@ pub fn arguments(input: TokenStream) -> TokenStream {
                 #version_string
             }
 
-            #[cfg(feature = "complete")]
             fn complete() -> ::uutils_args_complete::Command<'static> {
                 use ::uutils_args::Value;
                 #complete_command
@@ -212,7 +211,6 @@ pub fn value(input: TokenStream) -> TokenStream {
                 })
             }
 
-            #[cfg(feature = "complete")]
             fn value_hint() -> ::uutils_args_complete::ValueHint {
                 let keys: [&str; #keys_len] = [#(#all_keys),*];
                 ::uutils_args_complete::ValueHint::Strings(

--- a/docs/guide/completions.md
+++ b/docs/guide/completions.md
@@ -39,7 +39,7 @@ The `[shell]` value here can be `fish`, `zsh`, `nu`, `sh`, `bash`, `csh`, `elvis
 
 Additionally, the values `man` or `md` can be passed to generate man pages and markdown documentation (for `mdbook`).
 
-If you do not want to hijack the [`Options::parse`](crate::Options::parse) function, you can instead enable the `complete` feature flag. This makes the `Options::complete` function available in addition to the [`Options::parse`](crate::Options::parse) function to generate a `String` with the completion.
+If you do not want to hijack the [`Options::parse`](crate::Options::parse) function, you can instead use the `Options::complete` function available in addition to the [`Options::parse`](crate::Options::parse) function to generate a `String` with the completion.
 
 <div class="chapters">
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,6 @@ pub trait Arguments: Sized {
         Ok(())
     }
 
-    #[cfg(feature = "complete")]
     fn complete() -> uutils_args_complete::Command<'static>;
 }
 
@@ -197,7 +196,6 @@ pub trait Options<Arg: Arguments>: Sized {
         }
     }
 
-    #[cfg(feature = "complete")]
     fn complete(shell: &str) -> String {
         uutils_args_complete::render(&Arg::complete(), shell)
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,7 +6,6 @@ use std::{
     ffi::{OsStr, OsString},
     path::PathBuf,
 };
-#[cfg(feature = "complete")]
 use uutils_args_complete::ValueHint;
 
 pub type ValueResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
@@ -54,7 +53,6 @@ impl std::fmt::Display for ValueError {
 pub trait Value: Sized {
     fn from_value(value: &OsStr) -> ValueResult<Self>;
 
-    #[cfg(feature = "complete")]
     fn value_hint() -> ValueHint {
         ValueHint::Unknown
     }
@@ -71,7 +69,6 @@ impl Value for PathBuf {
         Ok(PathBuf::from(value))
     }
 
-    #[cfg(feature = "complete")]
     fn value_hint() -> ValueHint {
         ValueHint::AnyPath
     }
@@ -98,7 +95,6 @@ where
         Ok(Some(T::from_value(value)?))
     }
 
-    #[cfg(feature = "complete")]
     fn value_hint() -> uutils_args_complete::ValueHint {
         T::value_hint()
     }


### PR DESCRIPTION
This avoids using cfg with the destination-crate's feature "complete" in proc-macro "derive".

Quoting cargo:

    using a cfg inside a derive macro will use the cfgs from the
    destination crate and not the ones from the defining crate

In these two instances, the cfg was simply used to avoid emitting dead code if the "complete" feature is not desired. By passing the "complete" feature down to the derive crate and evaluating if there, we achieve the same goal, without having to deal with suprisingly-valued and unexpected cfgs downstream.

Discovered while trying to integrate uutils-args into coreutils: https://github.com/uutils/coreutils/actions/runs/14420666926/job/40442804575?pr=7739

**This is my preferred approach.**

Alternatively, we could just evaluate the flag inside the derive crate, and pass the feature flag to it, as implemented in #132.