### PR TITLE
Avoid using cfg with destination-crate feature in proc-macro derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ lexopt = "0.3.0"
 
 [features]
 parse-is-complete = ["complete"]
-complete = ["uutils-args-complete"]
+complete = ["uutils-args-complete", "uutils-args-derive/complete"]
 
 [workspace]
 members = ["derive", "complete"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -12,3 +12,6 @@ proc-macro = true
 proc-macro2 = "1.0.81"
 quote = "1.0.36"
 syn = { version = "2.0.60", features = ["full"] }
+
+[features]
+complete = []


### PR DESCRIPTION
Quoting cargo:

    using a cfg inside a derive macro will use the cfgs from the
    destination crate and not the ones from the defining crate

In these two instances, the cfg was simply used to avoid emitting dead code if the "complete" feature is not desired. By passing the "complete" feature down to the derive crate and evaluating if there, we achieve the same goal, without having to deal with suprisingly-valued and unexpected cfgs downstream.

Discovered while trying to integrate uutils-args into coreutils: https://github.com/uutils/coreutils/actions/runs/14420666926/job/40442804575?pr=7739

**This is not my favourite approach.**

Alternatively, we could just remove the feature-flag and make it part of the permanent API, as implemented in #131.