### PR TITLE
clippy: suppress warning from `large_enum_variant`

### DIFF
--- a/derive/src/attributes.rs
+++ b/derive/src/attributes.rs
@@ -69,6 +69,7 @@ impl ArgumentsAttr {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum ArgAttr {
     Option(OptionAttr),
     Free(FreeAttr),


### PR DESCRIPTION
This PR suppresses a warning from the [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant) lint.