### PR TITLE
clippy: fix warnings from `uninlined_format_args`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -105,7 +105,7 @@ impl Display for ErrorKind {
                 Ok(())
             }
             ErrorKind::UnexpectedArgument(arg) => {
-                write!(f, "Found an invalid argument '{}'.", arg)
+                write!(f, "Found an invalid argument '{arg}'.")
             }
             ErrorKind::UnexpectedValue { option, value } => {
                 write!(

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -134,14 +134,14 @@ pub fn print_flags(
                 }
             };
             let help_indent = " ".repeat(width - flags.len() + 2);
-            writeln!(w, "{}{}", help_indent, line).unwrap();
+            writeln!(w, "{help_indent}{line}").unwrap();
         } else {
             writeln!(w).unwrap();
         }
 
         let help_indent = " ".repeat(width + indent_size + 2);
         for line in help_lines {
-            writeln!(w, "{}{}", help_indent, line).unwrap();
+            writeln!(w, "{help_indent}{line}").unwrap();
         }
     }
 }

--- a/src/positional.rs
+++ b/src/positional.rs
@@ -209,7 +209,7 @@ fn assert_empty<T: Debug>(mut operands: Vec<T>) -> Result<(), Error> {
     if let Some(arg) = operands.pop() {
         return Err(Error {
             exit_code: 1,
-            kind: ErrorKind::UnexpectedArgument(format!("{:?}", arg)),
+            kind: ErrorKind::UnexpectedArgument(format!("{arg:?}")),
         });
     }
     Ok(())

--- a/tests/coreutils/cksum.rs
+++ b/tests/coreutils/cksum.rs
@@ -91,8 +91,7 @@ fn assert_format(args: &[&str], expected: ResultingFormat) {
     assert_eq!(
         (result.0.format(), result.1.as_slice()),
         (expected, [].as_slice()),
-        "{:?}",
-        args
+        "{args:?}"
     );
 }
 


### PR DESCRIPTION
This PR fixes warnings from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) lint.